### PR TITLE
ci: fix caching.

### DIFF
--- a/.github/workflows/ci_bionic.yml
+++ b/.github/workflows/ci_bionic.yml
@@ -37,10 +37,10 @@ jobs:
       - name: ccache cache files
         uses: actions/cache@v2
         with:
-          path: ${{ env.CI_NAME }}/.ccache
-          key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          path: ${{ env.OS_CODE_NAME }}/.ccache
+          key: ${{ env.OS_CODE_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ${{ env.CI_NAME }}-ccache-
+            ${{ env.OS_CODE_NAME }}-ccache-
 
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}

--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -37,10 +37,10 @@ jobs:
       - name: ccache cache files
         uses: actions/cache@v2
         with:
-          path: ${{ env.CI_NAME }}/.ccache
-          key: ${{ env.CI_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          path: ${{ env.OS_CODE_NAME }}/.ccache
+          key: ${{ env.OS_CODE_NAME }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ${{ env.CI_NAME }}-ccache-
+            ${{ env.OS_CODE_NAME }}-ccache-
 
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}


### PR DESCRIPTION
As per subject.

I accidentally used the wrong path to the `.ccache` dir in the settings for `industrial_ci`, which made it impossible for `ccache` inside the Docker image to find the cache, effectively disabling it.

It won't have a significant effect, as this repository only contains message packages, but it's nicer to correct it in any case.
